### PR TITLE
updates docs with new instructions

### DIFF
--- a/docs/runbooks/lifeboat-switchover.md
+++ b/docs/runbooks/lifeboat-switchover.md
@@ -12,16 +12,25 @@ In general, if us-east is having networking issues, you should be switching over
 
 ## How to switch to Lifeboat
 
-1. Go to the CloudFront Console in AWS.
-1. Select the CloudFront Distribution with name (Description) "production"--ID 	`E1M2MLYJK72V3I`.
+1. Login to Jenkins.
+1. Select the `Lifeboat-Cutover` Project.
+1. From the menu bar, select `Build with Parameters`.
+1. Select either `maintenance` or `failover` from the dropdown menu.
+1. Click `Build`.
+1. Confirm a successful build.
+1. To check the host is being routed to, go to eclkc.ohs.acf.hhs.gov/gethostname.php.
+    * If you’re on Varnish, you’ll have that name
+    * If you’re on Lifeboat, you’ll have `lifeboat.east.eclkc`
+
+## How to switch to ECLKC-Prod
+
+1. To switch back over, go to the CloudFront Console in AWS.
+1. Select the CloudFront Distribution with name (Description) "production"--ID `E1M2MLYJK72V3I`
 1. On the `Origins` tab, select `ECLKC` Origin and select `Edit`.
-1. Click `Origin domain` and select `ECLKC-Lifeboat` from the drop down menu. We are PRETTY sure they are ordered by region so that `us-east` always comes first, but confirm via DNS that you've selected the one you want because east and west instances both currently have the same name.
-    * You want the east instance in the case of a failover.
-    * You want the west instance in the case of maintenance.
+1. Click `Origin domain` and select `ECLKC-Reader-1685067169.us-east-1.elb.amazonaws.com` from the drop down menu.
 1. Scroll down and select `Save changes`.
 1. In the `Invalidations` tab, select `Create invalidation`.
 1. Add an object path of `/*` and select `Create invalidation`. The invalidation will take a minute or two to clear.
 1. To check the host is being routed to, go to eclkc.ohs.acf.hhs.gov/gethostname.php.
     * If you’re on Varnish, you’ll have that name
-    * If you’re on Lifeboat, you’ll have `lifeboat.east.eclkc`
-1. To switch back over, reverse these instructions to use the origin domain of `ECLKC-Reader-1685067169.us-east-1.elb.amazonaws.com`
+    * If you’re on Lifeboat, you’ll have `lifeboat.east.eclkc`.


### PR DESCRIPTION
# [Jenkins job for Lifeboat cutover](https://ocio-jira.acf.hhs.gov/browse/OHSH-168)

<!--
Please add context for changes.
 -  Updates the runbook for how to switch to maintenance or failover mode onto Lifeboat.
-->

Should only land with https://github.com/OHS-Hosting-Infrastructure/environment-configuration/pull/121
