### PR TITLE
Rek ohsh 203 prod cutover

### DIFF
--- a/docs/runbooks/lifeboat-switchover.md
+++ b/docs/runbooks/lifeboat-switchover.md
@@ -25,7 +25,7 @@ In general, if us-east is having networking issues, you should be switching over
 
 ## How to switch to ECLKC-Prod
 
-1. 1. Login to Jenkins.
+1. Login to Jenkins.
 1. Select the `ECLKC-Prod-Cutover` Project.
 1. From the menu bar, select `Build Now`.
 1. Confirm a successful build.

--- a/docs/runbooks/lifeboat-switchover.md
+++ b/docs/runbooks/lifeboat-switchover.md
@@ -2,13 +2,13 @@
 
 ## Context
 
-Lifeboat is the read-only version of the ECLKC Database that we can switch to during maintenance windows and in the case of an incident when the website is getting attacked.
+Lifeboat is the read-only version of the ECLKC Database that we can switch to during maintenance windows and in the case of an incident when the website is getting attacked (failover).
 
 Lifeboat sync jobs run every night around 11pm, so the database should be within 24 hours of up to date at all times. Before switching over, you should check that it successfully ran the night before. It generally takes about 15-20 minutes to sync the databases.
 
 If the sync job didn't run the night before, you should default to triggering it before switching over to Lifeboat. Of course, this won't be possible if there are networking issues.
 
-In general, if us-east is having networking issues, you should be switching over to us-west. If the database isn't working in us-east, but other things are okay, you can move to Lifeboat in east because it is a read-only copy of the previous night's database.
+In general, if us-east is having networking issues, you should be switching over to us-west (failover). If the database isn't working in us-east, but other things are okay, you can move to Lifeboat in east (maintenance) because it is a read-only copy of the previous night's database.
 
 ## How to switch to Lifeboat
 

--- a/docs/runbooks/lifeboat-switchover.md
+++ b/docs/runbooks/lifeboat-switchover.md
@@ -18,19 +18,18 @@ In general, if us-east is having networking issues, you should be switching over
 1. Select either `maintenance` or `failover` from the dropdown menu.
 1. Click `Build`.
 1. Confirm a successful build.
-1. To check the host is being routed to, go to eclkc.ohs.acf.hhs.gov/gethostname.php.
+1. To check the host that is being routed to, go to eclkc.ohs.acf.hhs.gov/gethostname.php.
     * If you’re on Varnish, you’ll have that name
-    * If you’re on Lifeboat, you’ll have `lifeboat.east.eclkc`
+    * If you’re on Lifeboat for maintenance, you’ll have `lifeboat.east.eclkc`
+    * If you’re on Lifeboat for failover, you’ll have `lifeboat.west.eclkc`
 
 ## How to switch to ECLKC-Prod
 
-1. To switch back over, go to the CloudFront Console in AWS.
-1. Select the CloudFront Distribution with name (Description) "production"--ID `E1M2MLYJK72V3I`
-1. On the `Origins` tab, select `ECLKC` Origin and select `Edit`.
-1. Click `Origin domain` and select `ECLKC-Reader-1685067169.us-east-1.elb.amazonaws.com` from the drop down menu.
-1. Scroll down and select `Save changes`.
-1. In the `Invalidations` tab, select `Create invalidation`.
-1. Add an object path of `/*` and select `Create invalidation`. The invalidation will take a minute or two to clear.
-1. To check the host is being routed to, go to eclkc.ohs.acf.hhs.gov/gethostname.php.
+1. 1. Login to Jenkins.
+1. Select the `ECLKC-Prod-Cutover` Project.
+1. From the menu bar, select `Build Now`.
+1. Confirm a successful build.
+1. To check the host that is being routed to, go to eclkc.ohs.acf.hhs.gov/gethostname.php.
     * If you’re on Varnish, you’ll have that name
-    * If you’re on Lifeboat, you’ll have `lifeboat.east.eclkc`.
+    * If you’re on Lifeboat for maintenance, you’ll have `lifeboat.east.eclkc`
+    * If you’re on Lifeboat for failover, you’ll have `lifeboat.west.eclkc`


### PR DESCRIPTION
# [203](https://ocio-jira.acf.hhs.gov/browse/OHSH-203) Create Jenkins job to automate switchover to prod eclkc alb.
Changes proposed in this pull request:

- Update runbook on how to switch back from lifeboat to prod instance

