### PR TITLE
updates readme as index and adds ansible how to

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,3 +1,37 @@
 # Runbooks
 
 This is where we'll store runbooks.
+
+[Debugging ECLKC During an Outage](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/debugging-eclkc-outage.md)
+
+[How to clean up mail on the mailserver](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-cleanup-mail.md)
+
+[How to create an ECLKC login](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-create-an-eclkc-login.md)
+
+[How to get SSH Access](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-get-ssh-access.md)
+[How to grant SFTP Access](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-grant-sftp-access.md)
+[How to manage ECLKC.info emails](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-manage-eclkcinfo-emails.md)
+
+[How to manage Qualys](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-manage-qualys.md)
+
+[How to onboard a new application](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/onboard-a-new-app.md)
+
+[How to onboard a new hosting team member](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/onboard-a-new-hosting-team-member.md)
+
+[How to Push and Pull Docker Images from an ECR repo](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/push-pull-docker.md)
+
+[How to request an emergency change request](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/emergency-change-request.md)
+
+[How to support the eclkc drupal deployment](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-support-eclkc-drupal-deploy.md)
+
+[Lifeboat Switchover](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/lifeboat-switchover.md)
+
+[Maintenance](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/maintenance.md)
+
+[Restore DB on the ec2 MariaDB](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/restore-db-mariadb.md)
+
+[Update SSL Cert](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/update-ssl-certs.md)
+
+[Updating the Coaching Companion Staging Database](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/db-switchover-for-coaching-companion.md)
+
+[VPN Access Policies](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/vpn-access-requests.md)

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -22,6 +22,8 @@ This is where we'll store runbooks.
 
 [How to request an emergency change request](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/emergency-change-request.md)
 
+[How to run Ansible commands](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-run-ansible-commands.md)
+
 [How to support the eclkc drupal deployment](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/how-to-support-eclkc-drupal-deploy.md)
 
 [Lifeboat Switchover](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/runbooks/lifeboat-switchover.md)

--- a/docs/runbooks/how-to-run-ansible-commands.md
+++ b/docs/runbooks/how-to-run-ansible-commands.md
@@ -1,0 +1,17 @@
+# How to run Ansible commands
+
+## Context
+
+We are using Ansible for more automation. At some point we will have it set up so you don't have to SSH into the server to run the command, but for now, this should help you get where you need to go.
+
+## Steps
+
+1. Develop your code in the [environmental-config repo](https://github.com/OHS-Hosting-Infrastructure/environment-configuration).
+1. Copy the code you've written into the `/home/centos/ansible` directory on the Ansible machine (probably via scp e.g. `scp -r ansible/* centos@10.2.0.6:ansible/` where the initial argument is the location of your local changes).
+1. SSH into the Ansible machine as the centos user.
+1. `cd ansible` to access the ansible directory.
+1. Run `ansible-playbook -i inventory <YOUR-RUNBOOK.yml> --check` to dryrun your code. Make sure it appears to work correctly.
+1. You may choose to request a PR here in case you want eyes on the runbook before actually executing.
+1. Run `ansible-playbook -i inventory <YOUR-RUNBOOK.yml>` to actually run the runbook.
+1. Test your runbook worked as expected.
+1. If you didn't request a PR before, do so now and merge your code.

--- a/docs/runbooks/how-to-run-ansible-commands.md
+++ b/docs/runbooks/how-to-run-ansible-commands.md
@@ -10,8 +10,8 @@ We are using Ansible for more automation. At some point we will have it set up s
 1. Copy the code you've written into the `/home/centos/ansible` directory on the Ansible machine (probably via scp e.g. `scp -r ansible/* centos@10.2.0.6:ansible/` where the initial argument is the location of your local changes).
 1. SSH into the Ansible machine as the centos user.
 1. `cd ansible` to access the ansible directory.
-1. Run `ansible-playbook -i inventory <YOUR-RUNBOOK.yml> --check` to dryrun your code. Make sure it appears to work correctly.
-1. You may choose to request a PR here in case you want eyes on the runbook before actually executing.
-1. Run `ansible-playbook -i inventory <YOUR-RUNBOOK.yml>` to actually run the runbook.
-1. Test your runbook worked as expected.
-1. If you didn't request a PR before, do so now and merge your code.
+1. Run `ansible-playbook <YOUR-RUNBOOK.yml> --check` to dryrun your code. Make sure it appears to work correctly.
+1. Request a PR here to get eyes on the runbook before actually executing.
+1. Run `ansible-playbook <YOUR-RUNBOOK.yml>` to actually run the runbook.
+1. Test your runbook worked as expected. This likely means ssh'ing to the *remote host* you're configuring and verifying expected changes were made.
+1. Merge your approved PR.


### PR DESCRIPTION
# [Related to OHS-369--create a how to for using Ansible](https://ocio-jira.acf.hhs.gov/browse/OHSH-369)

<!--
Adds a runbook for using Ansible (related to this: https://github.com/OHS-Hosting-Infrastructure/environment-configuration/pull/129). 
-->

Changes proposed in this pull request:

- Updates the Readme to link to all the dir's contents
- Creates a how to for running Ansible for now.
