### PR TITLE
Remove shared slack channel intro onboarding step

### DIFF
--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -6,6 +6,11 @@ This is a checklist for onboarding a new Headstart hosting team member.
 
 __The new team member__ will need to complete the following:
 
+- [ ] Introduce yourself to the team on Slack, use #pb-ohs-hsis-vendors (the shared 18f/Truss channel):
+  - [ ]  Where are you located?
+  - [ ]  What are your working hours?
+  - [ ]  What is your favorite food?
+  - [ ]  What is your GitHub user name?
 - [ ] [Create ECLKC logins](./how-to-create-an-eclkc-login.md):
   - [ ]  Dev
     - [ ] Provide this username to the existing team member helping you onboard to get Jenkins access.

--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -6,11 +6,6 @@ This is a checklist for onboarding a new Headstart hosting team member.
 
 __The new team member__ will need to complete the following:
 
-- [ ] Introduce yourself to the team on Slack, use #pb-ohs-hsis-vendors (the shared 18f/Truss channel):
-  - [ ]  Where are you located?
-  - [ ]  What are your working hours?
-  - [ ]  What is your favorite food?
-  - [ ]  What is your GitHub user name?
 - [ ] [Create ECLKC logins](./how-to-create-an-eclkc-login.md):
   - [ ]  Dev
     - [ ] Provide this username to the existing team member helping you onboard to get Jenkins access.

--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -6,7 +6,7 @@ This is a checklist for onboarding a new Headstart hosting team member.
 
 __The new team member__ will need to complete the following:
 
-- [ ] Introduce yourself to the team on Slack, use #pb-ohs-hsis-vendors (the shared 18f/Truss channel):
+- [ ] Introduce yourself to the team on the [shared Slack server](https://app.slack.com/client/T025YR8S487/C026S711T6D):
   - [ ]  Where are you located?
   - [ ]  What are your working hours?
   - [ ]  What is your favorite food?


### PR DESCRIPTION
# Not Jira

<!--
Please add context for changes.
 - What is the problem we solve in this PR?
-->

- Remove shared slack channel intro onboarding step

Per Sanjay, we are no longer using this channel in favor of the shared OHS workspace.