### PR TITLE
Remove obsolete onboarding instructions

### DIFF
--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -16,6 +16,7 @@ __The new team member__ will need to complete the following:
     - [ ] Provide this username to the existing team member helping you onboard to get Jenkins access.
   - [ ]  Staging
   - [ ]  Prod
+- [ ] Ask Sam Nevares in the Headstart Slack to be added to the [HSICC Github org](https://github.com/HSICC)
 
 __An existing team member__ will need to give the new member access to the following:
 

--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -19,6 +19,7 @@ __The new team member__ will need to complete the following:
 
 __An existing team member__ will need to give the new member access to the following:
 
+- [ ] Add the new member to the team google groups (`headstart-hosting@truss.works` and `headstart-alerts@truss.works`)
 - [ ] Add the new member to existing calendar invites. This may mean reaching out to the HSICC team.
 - [ ] [GitHub Org](https://docs.github.com/en/organizations/managing-membership-in-your-organization/inviting-users-to-join-your-organization)
 - [ ] [Qualys](./how-to-manage-qualys.md)

--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -21,7 +21,6 @@ __An existing team member__ will need to give the new member access to the follo
 
 - [ ] Add the new member to existing calendar invites. This may mean reaching out to the HSICC team.
 - [ ] [GitHub Org](https://docs.github.com/en/organizations/managing-membership-in-your-organization/inviting-users-to-join-your-organization)
-- [ ] AWS (Read only)
 - [ ] [Qualys](./how-to-manage-qualys.md)
 
 ## Post Favorable Security Review

--- a/docs/runbooks/onboard-a-new-hosting-team-member.md
+++ b/docs/runbooks/onboard-a-new-hosting-team-member.md
@@ -19,10 +19,6 @@ __The new team member__ will need to complete the following:
 
 __An existing team member__ will need to give the new member access to the following:
 
-- [ ] [Add the new member to alias email lists](./how-to-manage-eclkcinfo-emails.md).
-  - [ ] sysadmin@eclkc.info
-  - [ ] hslcadmin@eclkc.info
-  - [ ] jenkins-alerts@eclkc.info
 - [ ] Add the new member to existing calendar invites. This may mean reaching out to the HSICC team.
 - [ ] [GitHub Org](https://docs.github.com/en/organizations/managing-membership-in-your-organization/inviting-users-to-join-your-organization)
 - [ ] AWS (Read only)


### PR DESCRIPTION
# Not Jira

<!--
Please add context for changes.
 - What is the problem we solve in this PR?
-->

Changes proposed in this pull request:

- Remove onboarding instruction about AWS read only access.
- Remove onboarding instruction about email lists
