### PR TITLE
Add end-of-file-fixer hook to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
         args:
           - --autofix
       - id: trailing-whitespace
+      - id: end-of-file-fixer
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.11


### PR DESCRIPTION
# Not Jira

Changes proposed in this pull request:

- Add `end-of-file-fixer` to pre-commit config.
