### PR TITLE
Update git protocols from git:// to https:// in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: check-json
@@ -21,7 +21,7 @@ repos:
           - mdformat-gfm
           - mdformat-toc
 
-  - repo: git://github.com/detailyang/pre-commit-shell
+  - repo: https://github.com/detailyang/pre-commit-shell
     rev: 1.0.5
     hooks:
       - id: shell-lint


### PR DESCRIPTION
# Background

github recently rolled out some breaking changes to their protocol security posture. [Further reading](https://github.blog/2021-09-01-improving-git-protocol-security-github/)

The `git://` protocol is no longer supported. Our pre-commit hooks are set to use this protocol, which will cause pre-commit to break locally and in CI with a cryptic error like so:

```
[INFO] Initializing environment for git://github.com/pre-commit/pre-commit-hooks.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags')
return code: 128
expected return code: 0
stdout: (none)
stderr:
    fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
    
Check the log at /home/circleci/.cache/pre-commit/pre-commit.log

Exited with code exit status 1
```

# Fix

This PR fixes the problem by replacing `git://` with `https://` in the pre-commit config.