### PR TITLE
OHSH-520 add initial private ca documentation

### DIFF
--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -1,6 +1,6 @@
 ## Private Certificate Authority (CA) Background and Creation
 
-The OHS private CA was created using the [ACM Private Certificate Authority](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaWelcome.html) Terraform [module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority). Note that as stated in the Terraform module, a the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active. This is a one time action that only has to be done when creating a new Private CA.
+The OHS private CA was created using the [ACM Private Certificate Authority](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaWelcome.html) Terraform [module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority). Note that as stated in the Terraform module, the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active. This is a one time action that only has to be done when creating a new Private CA.
 
 ## Creating Certificate With Private CA
 

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -1,10 +1,10 @@
 ## Private Certificate Authority (CA) Background and Creation
 
-Details about the OHS Private CA can be found in the the ACM Portion of the AWS Console. The private CA was created using the [acmpca certificate authority](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority) terraform module. Note that as stated in the terraform module, a the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active.
+The OHS private CA was created using the [acmpca certificate authority](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority) terraform module. Note that as stated in the terraform module, a the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active. This is a one time action that only has to be done when creating a new Private CA.
 
 ## Creating Certificate With Private CA
 
-Certificates can be created manually via the ACM console but the preference is via terraform. An example of a certificate created with our private CA via terraform is below:
+Certificates can be created manually via the ACM console but the preference is to create certificates via terraform when possible. An example of a certificate created with our private CA via terraform is below:
 
 ```
 resource "aws_acm_certificate" "cert_name" {
@@ -38,7 +38,7 @@ certificate_arn   = aws_acm_certificate.cert_name.arn
 
 ## Resolving Cert Errors
 
-Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by our Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine, and "trust" it. The root CA certificate can be found on AWS in the ACM console.
+Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by the OHS Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine, and "trust" it. The root CA certificate can be found on AWS in the ACM console.
 
 For Mac OS run the following:
 

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -43,7 +43,7 @@ Without any modifications to your local machine "trust" settings, navigating to 
 For Mac OS navigate to your home directory and run the following:
 
 ```
-sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/ohs-private-ca-cert.pem
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ohs-private-ca-cert.pem
 ```
 
 For Windows navigate to your home directory and run the following:

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -38,7 +38,7 @@ certificate_arn   = aws_acm_certificate.cert_name.arn
 
 ## Resolving Cert Errors
 
-Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by the OHS Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine in your home directory as  `ohs-private-ca-cert.pem`, and "trust" it. The root CA certificate can be found on AWS in the ACM console. 
+Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by the OHS Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine in your home directory as  `ohs-private-ca-cert.pem`, and "trust" it. The root CA certificate can be found on AWS in the ACM console.
 
 For Mac OS navigate to your home directory and run the following:
 

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -1,6 +1,6 @@
 ## Private Certificate Authority (CA) Background and Creation
 
-The OHS private CA was created using the [acmpca certificate authority](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority) terraform module. Note that as stated in the terraform module, a the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active. This is a one time action that only has to be done when creating a new Private CA.
+The OHS private CA was created using the [ACM Private Certificate Authority](https://docs.aws.amazon.com/acm-pca/latest/userguide/PcaWelcome.html) Terraform [module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority). Note that as stated in the Terraform module, a the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active. This is a one time action that only has to be done when creating a new Private CA.
 
 ## Creating Certificate With Private CA
 

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -2,7 +2,7 @@
 
 Details about the OHS Private CA can be found in the the ACM Portion of the AWS Console. The private CA was created using the [acmpca certificate authority](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acmpca_certificate_authority) terraform module. Note that as stated in the terraform module, a the manual step of installing the root CA certificate from the console is required to change the status of the CA from pending to active.
 
-## Creating Certificate With Private CA 
+## Creating Certificate With Private CA
 
 Certificates can be created manually via the ACM console but the preference is via terraform. An example of a certificate created with our private CA via terraform is below:
 
@@ -15,6 +15,7 @@ resource "aws_acm_certificate" "cert_name" {
   }
 }
 ```
+
 ## Importing Private CA For Use in Terraform
 
 Terraform supports importing a aws_acmpca_certificate_authority resource as a datatype by it's arn. An example of this is below:
@@ -24,29 +25,34 @@ data "aws_acmpca_certificate_authority" "example" {
   arn = "arn:aws:acm-pca:us-east-1:123456789012:certificate-authority12345678-012"
 }
 ```
+
 More information about importing a private CA via terraform can be found [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acmpca_certificate_authority)
 
 ## Using a Private CA Cert
+
 A certificate can be referenced / used with it's arn:
 
 ```
 certificate_arn   = aws_acm_certificate.cert_name.arn
-```                                 
+```
 
 ## Resolving Cert Errors
 
-Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by our Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine, and "trust" it. The root CA certificate can be found on AWS in the ACM console. 
+Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by our Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine, and "trust" it. The root CA certificate can be found on AWS in the ACM console.
 
 For Mac OS run the following:
+
 ```
 sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/new-root-certificate.crt
 ```
 
 For Windows:
+
 ```
 certutil -addstore -f "ROOT" new-root-certificate.crt
 ```
 
-For more information about resolving cert errors view the following resources and documentation: 
+For more information about resolving cert errors view the following resources and documentation:
+
 - [add-trusted-cert man page](https://www.unix.com/man-page/mojave/1/security)
 - [certutil documentation](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -18,7 +18,7 @@ resource "aws_acm_certificate" "cert_name" {
 
 ## Importing Private CA For Use in Terraform
 
-Terraform supports importing a aws_acmpca_certificate_authority resource as a datatype by its arn. An example of this is below:
+Terraform supports importing a aws_acmpca_certificate_authority resource as a datatype by its arn, if needed to be used in a different terraform stack. An example of this is below:
 
 ```
 data "aws_acmpca_certificate_authority" "example" {
@@ -38,15 +38,15 @@ certificate_arn   = aws_acm_certificate.cert_name.arn
 
 ## Resolving Cert Errors
 
-Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by the OHS Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine, and "trust" it. The root CA certificate can be found on AWS in the ACM console.
+Without any modifications to your local machine "trust" settings, navigating to a website that uses a certificate signed by the OHS Private CA will result in certificate errors. To resolve these, you must download and save a copy of the root CA cert on your local machine in your home directory as  `ohs-private-ca-cert.pem`, and "trust" it. The root CA certificate can be found on AWS in the ACM console. 
 
-For Mac OS run the following:
+For Mac OS navigate to your home directory and run the following:
 
 ```
-sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/new-root-certificate.crt
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/ohs-private-ca-cert.pem
 ```
 
-For Windows:
+For Windows navigate to your home directory and run the following:
 
 ```
 certutil -addstore -f "ROOT" new-root-certificate.crt

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -18,7 +18,7 @@ resource "aws_acm_certificate" "cert_name" {
 
 ## Importing Private CA For Use in Terraform
 
-Terraform supports importing a aws_acmpca_certificate_authority resource as a datatype by it's arn. An example of this is below:
+Terraform supports importing a aws_acmpca_certificate_authority resource as a datatype by its arn. An example of this is below:
 
 ```
 data "aws_acmpca_certificate_authority" "example" {

--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -26,7 +26,7 @@ data "aws_acmpca_certificate_authority" "example" {
 }
 ```
 
-More information about importing a private CA via terraform can be found [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acmpca_certificate_authority)
+More information about importing a private CA via terraform can be found [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acmpca_certificate_authority).
 
 ## Using a Private CA Cert
 


### PR DESCRIPTION
# [Document how to use the Private Certificate Authority in AWS](https://ocio-jira.acf.hhs.gov/browse/OHSH-520)

Changes proposed in this pull request:

- Adding documentation around how to use Private CA to create certificates

