### PR TITLE
Private CA - add documentation that cert can be deleted after trusting

### DIFF
--- a/docs/how-we-work/private-ca.md
+++ b/docs/how-we-work/private-ca.md
@@ -52,6 +52,8 @@ For Windows navigate to your home directory and run the following:
 certutil -addstore -f "ROOT" new-root-certificate.crt
 ```
 
+If desired, after running these commands, you can remove the certificate from your local machine.
+
 For more information about resolving cert errors view the following resources and documentation:
 
 - [add-trusted-cert man page](https://www.unix.com/man-page/mojave/1/security)


### PR DESCRIPTION
[OHSH-549](https://ocio-jira.acf.hhs.gov/browse/OHSH-549)

Changes proposed in this pull request:

- add documentation that cert can be deleted after trusting if desired
