### PR TITLE
Add documentation for external services that need access to Jenkins

### DIFF
--- a/docs/research/jenkins-external-services.md
+++ b/docs/research/jenkins-external-services.md
@@ -1,6 +1,5 @@
 # Jenkins External Services Documentation
 
-
 ## Background
 
 Research on which external services need access to Jenkins is necessary in the process of moving Jenkins behind the VPN. The [design doc](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/design-docs/moving-jenkins-behind-vpn.md) for this provides additional information.

--- a/docs/research/jenkins-external-services.md
+++ b/docs/research/jenkins-external-services.md
@@ -1,19 +1,20 @@
 # Jenkins External Services Documentation
 
-Two main services that need access to Jenkins will need to be accounted for when moving it behind the VPN: Bitbucket and Box. HSICC is looking to move away from using Github so we've been told that we don't need to consider it in our plans. A brief description of each service and how it interacts with Jenkins is below. 
+Two main services that need access to Jenkins will need to be accounted for when moving it behind the VPN: Bitbucket and Box. HSICC is looking to move away from using Github so we've been told that we don't need to consider it in our plans. A brief description of each service and how it interacts with Jenkins is below.
 
 ## Bitbucket
 
-Jenkins makes a request to clone / download code from Bitbucket, however certain jobs are also triggered by Bitbucket. In these cases, Bitbucket sends a request via webhook to Jenkins, to trigger a job. 
+Jenkins makes a request to clone / download code from Bitbucket, however certain jobs are also triggered by Bitbucket. In these cases, Bitbucket sends a request via webhook to Jenkins, to trigger a job.
 
 The following job is triggered by Bitbucket (there may be more, but this is the one sent to us by HSICC):
+
 - BitBucket-drupal-composer-project
 
-  
 ## Box
 
-There are two similar jobs, one for Development and one for Production, that are triggered when files are added to a specific folder in Box for the HSICC team. Box sends a request via webhook to Jenkins, and this triggers the job. 
+There are two similar jobs, one for Development and one for Production, that are triggered when files are added to a specific folder in Box for the HSICC team. Box sends a request via webhook to Jenkins, and this triggers the job.
 
 Jobs that are triggered via Box are listed below:
+
 - Production - Learning Modules Security Check
 - Development - Learning Modules Security Check

--- a/docs/research/jenkins-external-services.md
+++ b/docs/research/jenkins-external-services.md
@@ -1,7 +1,19 @@
-# Jenkins External Services Documention
+# Jenkins External Services Documentation
 
-2 main services will need 
+Two main services that need access to Jenkins will need to be accounted for when moving it behind the VPN: Bitbucket and Box. HSICC is looking to move away from using Github so we've been told that we don't need to consider it in our plans. A brief description of each service and how it interacts with Jenkins is below. 
 
-- Bitbucket
+## Bitbucket
+
+Jenkins makes a request to clone / download code from Bitbucket, however certain jobs are also triggered by Bitbucket. In these cases, Bitbucket sends a request via webhook to Jenkins, to trigger a job. 
+
+The following job is triggered by Bitbucket (there may be more, but this is the one sent to us by HSICC):
+- BitBucket-drupal-composer-project
+
   
-- Box
+## Box
+
+There are two similar jobs, one for Development and one for Production, that are triggered when files are added to a specific folder in Box for the HSICC team. Box sends a request via webhook to Jenkins, and this triggers the job. 
+
+Jobs that are triggered via Box are listed below:
+- Production - Learning Modules Security Check
+- Development - Learning Modules Security Check

--- a/docs/research/jenkins-external-services.md
+++ b/docs/research/jenkins-external-services.md
@@ -1,0 +1,7 @@
+# Jenkins External Services Documention
+
+2 main services will need 
+
+- Bitbucket
+  
+- Box

--- a/docs/research/jenkins-external-services.md
+++ b/docs/research/jenkins-external-services.md
@@ -1,6 +1,11 @@
 # Jenkins External Services Documentation
 
-Two main services that need access to Jenkins will need to be accounted for when moving it behind the VPN: Bitbucket and Box. HSICC is looking to move away from using Github so we've been told that we don't need to consider it in our plans. A brief description of each service and how it interacts with Jenkins is below.
+
+## Background
+
+Research on which external services need access to Jenkins is necessary in the process of moving Jenkins behind the VPN. The [design doc](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/design-docs/moving-jenkins-behind-vpn.md) for this provides additional information.
+
+Two main services that need access to Jenkins will need to be accounted for: Bitbucket and Box. HSICC is looking to move away from using Github so we've been told that we don't need to consider it in our plans. A brief description of each service and how it interacts with Jenkins is below.
 
 ## Bitbucket
 


### PR DESCRIPTION
[OHSH-540](https://ocio-jira.acf.hhs.gov/browse/OHSH-540)

Changes proposed in this pull request:

- add documentation for external services that need access to Jenkins