### PR TITLE
OHSH-540 add link to jenkins external service research doc in Jenkins VPN design doc

### DIFF
--- a/docs/design-docs/moving-jenkins-behind-vpn.md
+++ b/docs/design-docs/moving-jenkins-behind-vpn.md
@@ -23,7 +23,7 @@ Adding a security group rule to the Jenkins EC2 instance to block HTTP traffic f
 1. Inform teams of upcoming changes regarding accessing Jenkins. This will include:
    - Letting teams know that in the future they will have to be connected to the VPN to access Jenkins
    - Sending teams new DNS name for Jenkins
-   - Checking to see if any teams have incoming webhooks into Jenkins configured that could be affected by moving Jenkins behind the VPN. We know there is interaction between GitHub, BitBucket and Box with Jenkins. We will need to investigate whether these are inbound or outbound. Research on external services that need access can be found [here](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/research/jenkins-external-services.md)
+   - Checking to see if any teams have incoming webhooks into Jenkins configured that could be affected by moving Jenkins behind the VPN. We know there is interaction between GitHub, BitBucket and Box with Jenkins. We will need to investigate whether these are inbound or outbound. Research on external services that need access can be found [here](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/research/jenkins-external-services.md).
    - Asking teams to see if additional VPN access will need to be granted for members who need to use Jenkins
 1. Remove the security group rule that currently allows HTTP access externally from the public internet.
 1. Test to make sure that the new DNS name routes properly from the browser when connected to the VPN (and does not work when connecting from the public internet). Verify that there are no issus with Github, BitBucket, and Box accessing Jenkins along with other functionality as well.

--- a/docs/design-docs/moving-jenkins-behind-vpn.md
+++ b/docs/design-docs/moving-jenkins-behind-vpn.md
@@ -23,7 +23,7 @@ Adding a security group rule to the Jenkins EC2 instance to block HTTP traffic f
 1. Inform teams of upcoming changes regarding accessing Jenkins. This will include:
    - Letting teams know that in the future they will have to be connected to the VPN to access Jenkins
    - Sending teams new DNS name for Jenkins
-   - Checking to see if any teams have incoming webhooks into Jenkins configured that could be affected by moving Jenkins behind the VPN.We know there is interaction between GitHub, BitBucket and Box with Jenkins. We will need to investigate whether these are inbound or outbound.
+   - Checking to see if any teams have incoming webhooks into Jenkins configured that could be affected by moving Jenkins behind the VPN. We know there is interaction between GitHub, BitBucket and Box with Jenkins. We will need to investigate whether these are inbound or outbound. Research on external services that need access can be found [here](https://github.com/OHS-Hosting-Infrastructure/infrastructure/blob/main/docs/research/jenkins-external-services.md)
    - Asking teams to see if additional VPN access will need to be granted for members who need to use Jenkins
 1. Remove the security group rule that currently allows HTTP access externally from the public internet.
 1. Test to make sure that the new DNS name routes properly from the browser when connected to the VPN (and does not work when connecting from the public internet). Verify that there are no issus with Github, BitBucket, and Box accessing Jenkins along with other functionality as well.


### PR DESCRIPTION
[OHSH-540](https://ocio-jira.acf.hhs.gov/browse/OHSH-540)

Changes proposed in this pull request:

- Add a link link to Jenkins external services research doc in Jenkins VPN design doc
